### PR TITLE
Ignore cache if AWS_NOCACHE is set.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,3 +2,11 @@ aws-profile
 ===========
 
 Wrapper script to generate &amp; pass AWS AssumeRole keys to other scripts
+
+Additions
+
+* Set the AWS_CACHE environment variable to control caching.
+  Use `AWS_CACHE=false` to disable caching, or any other value
+  (or unset) to keep caching enabled. When set to false the MFA
+  code will be requested every time.
+

--- a/awsprofile/__init__.py
+++ b/awsprofile/__init__.py
@@ -40,6 +40,13 @@ def configure_cache(session):
 
 def parse_args(argv=sys.argv):
     profile = os.getenv('AWS_DEFAULT_PROFILE')
+    cache = os.getenv('AWS_CACHE','true')
+
+    if cache.lower() != 'false':
+        cache = 'true'
+    else:
+        cache = 'false'
+
     if not profile: profile = os.getenv('AWS_PROFILE')
 
     if not profile and len(argv) >= 3:
@@ -50,12 +57,13 @@ def parse_args(argv=sys.argv):
         quit(1)
 
     command = argv[1:]
-    return (profile, command)
+    return (profile, command, cache)
 
 def main():
-    profile, command = parse_args()
+    profile, command, cache = parse_args()
     session = botocore.session.Session(profile=profile)
-    configure_cache(session)
+    if cache == 'true':
+        configure_cache(session)
     config = session.get_scoped_config()
     creds = session.get_credentials()
 


### PR DESCRIPTION
So I can force a new token (request for MFA) and I will know it will last for token-timeout!