### PR TITLE
Improve exit code handling

### DIFF
--- a/awsprofile/__init__.py
+++ b/awsprofile/__init__.py
@@ -92,7 +92,7 @@ def main():
         command, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr
     )
 
-    exit(os.WEXITSTATUS(returncode))
+    exit(sys.exit(returncode))
 
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 requires = [
+    'awscli>=1.16.31',
     'botocore>=1.3.15'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 requires = [
-    'awscli>=1.16.31',
     'botocore>=1.3.15'
 ]
 


### PR DESCRIPTION
When using aws-profile to run commands which return exit codes > 128 the
exit code is shifted to return just the first 8 bits (See the shells and
scripts section of https://en.wikipedia.org/wiki/Exit_status#Shell_and_scripts).
This is due to the use of os.WEXITSTATUS

Switching to use sys.exit causes the actual return code of the called
script to be returned. This was brought to light when attempting to use
the awscli and the return code was 255, but the aws-profile returned
zero. This resulted in incorrect control flow in the wrapping script.