### PR TITLE
Introduce cleaner selection of AWS profiles

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,13 +22,15 @@ Wrapper script to generate and pass AWS AssumeRole keys to other scripts
 Usage
 -----
 
-There are two primary ways to use **aws-profile**, inline and with environment variables.
+There are two primary ways to use **aws-profile**, inline using arguments and with environment variables.
 
 **Inline Profile Name**
 
-`aws-profile <profile> <command>`
+`aws-profile [-p, --profile <profile name>] <command>`
 
 **Profile Environment Variable**
+
+`AWS_DEFAULT_PROFILE='<profile>' aws-profile <command>`
 
 `AWS_PROFILE='<profile>' aws-profile <command>`
 


### PR DESCRIPTION
As mention in https://github.com/jrstarke/aws-profile/pull/5 botocore already handles picking and selecting AWS profile names from
AWS_PROFILE and AWS_DEFAULT_PROFILE so removing them and introducing a
named argument as a way of overriding environment variables seems to
make the usage and testability cleaner.

This is a breaking change so anyone who was using positional argument
for the profile will have issues when upgrading.

@ouroboros8 does this implement what you raised in #5 ?