### PR TITLE
Version 0.5.0 is broken on Ubuntu 18.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+DO NOT MERGE
+
 aws-profile
 ===========
 


### PR DESCRIPTION
$ aws-profile xxx aws
Traceback (most recent call last):
  File "/usr/local/bin/aws-profile", line 11, in <module>
    load_entry_point('aws-profile==0.5.0', 'console_scripts', 'aws-profile')()
  File "/usr/local/lib/python2.7/dist-packages/awsprofile/__init__.py", line 90, in main
    command, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr
  File "/usr/lib/python2.7/subprocess.py", line 172, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 394, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1047, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory

Rolling back to version 0.4.2 works fine