### PR TITLE
Added support for region overwrite

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,14 +26,13 @@ There are two primary ways to use **aws-profile**, inline using arguments and wi
 
 **Inline Profile Name**
 
-`aws-profile [-p, --profile <profile name>] <command>`
+`aws-profile [-p, --profile <profile name> -r, --region <region>] <command>`
 
 **Profile Environment Variable**
 
-`AWS_DEFAULT_PROFILE='<profile>' aws-profile <command>`
-
-`AWS_PROFILE='<profile>' aws-profile <command>`
-
+`aws-profile --profile dev --region us-west-2 <command>`
+or
+`aws-profile -p dev -r us-west-2 <command>`
 
 Options
 -------

--- a/awsprofile/__init__.py
+++ b/awsprofile/__init__.py
@@ -41,8 +41,15 @@ def configure_cache(session):
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--profile", help="set the AWS profile to use, this would override AWS environment variables",
-                        required=False, default=None)
+    parser.add_argument("-p", "--profile",
+                        help="set the AWS profile to use, this would override AWS environment variables",
+                        required=False,
+                        default=None)
+    parser.add_argument("-r", "--region",
+                        help="set the AWS region to use, this would override AWS environment variables",
+                        required=False,
+                        default=None)
+
     parser.add_argument("command", nargs=argparse.REMAINDER)
     args = parser.parse_args()
 
@@ -56,11 +63,11 @@ def parse_args():
     if not args.command:
         parser.print_help()
         sys.exit(1)
-    return (args.profile, args.command, cache)
+    return (args.profile, args.region, args.command, cache)
 
 
 def main():
-    profile, command, cache = parse_args()
+    profile, region, command, cache = parse_args()
     session = botocore.session.Session(profile=profile)
     if cache == 'true':
         configure_cache(session)
@@ -72,7 +79,8 @@ def main():
     os.unsetenv('AWS_SECRET_ACCESS_KEY')
     os.unsetenv('AWS_SESSION_TOKEN')
 
-    region = config.get('region', None)
+    region = region if region is not None else config.get('region', None)
+
     if region:
         os.putenv('AWS_DEFAULT_REGION', region)
         os.putenv('AWS_REGION', region)

--- a/awsprofile/__init__.py
+++ b/awsprofile/__init__.py
@@ -81,6 +81,9 @@ def main():
 
     region = region if region is not None else config.get('region', None)
 
+    if profile:
+        os.putenv('AWS_PROFILE', profile)
+
     if region:
         os.putenv('AWS_DEFAULT_REGION', region)
         os.putenv('AWS_REGION', region)

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 requires = [
-    'botocore>=1.15.20',
-    'awscli>=1.18.20'
+    'botocore>=1.3.15',
+    'awscli>=1.14.10'
 ]
 
 # Get the long description from the README file

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 requires = [
-    'botocore>=1.3.15',
-    'awscli>=1.14.10'
+    'botocore>=1.15.20',
+    'awscli>=1.18.20'
 ]
 
 # Get the long description from the README file

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,7 +9,7 @@ import awsprofile
 def test_returns_correct_exit_code(exit_code, mocker):
     """The function exits with the same exit code as the command executed within the valid exit code ranges of 0 - 255 AND the correct AWS related environment variables are set"""
     mock_parse_args = mocker.patch('awsprofile.parse_args')
-    mock_parse_args.return_value = ('profile-from-aws-profile-envvar', ['test-command-name'], 'true')
+    mock_parse_args.return_value = ('profile-from-aws-profile-envvar', None, ['test-command-name'], 'true')
     mock_subprocess_call = mocker.patch('awsprofile.subprocess.call')
     mock_subprocess_call.return_value = exit_code
     mocker.patch.object(awsprofile.botocore.session.Session, 'get_credentials')
@@ -22,8 +22,9 @@ def test_returns_correct_exit_code(exit_code, mocker):
     with pytest.raises(SystemExit) as system_exit:
         awsprofile.main()
     assert system_exit.value.code == exit_code
-    assert mock_put_env.call_count == 3
-    assert mock_put_env.call_args_list == [mocker.call('AWS_ACCESS_KEY_ID', 'FAKE_ACCESS_{}'.format(exit_code)),
+    assert mock_put_env.call_count == 4
+    assert mock_put_env.call_args_list == [mocker.call('AWS_PROFILE', 'profile-from-aws-profile-envvar'),
+                                           mocker.call('AWS_ACCESS_KEY_ID', 'FAKE_ACCESS_{}'.format(exit_code)),
                                            mocker.call('AWS_SECRET_ACCESS_KEY', 'FAKE_SECRET_{}'.format(exit_code)),
                                            mocker.call('AWS_SESSION_TOKEN', 'FAKE_TOKEN_{}'.format(exit_code))]
 
@@ -31,7 +32,7 @@ def test_returns_correct_exit_code(exit_code, mocker):
 def test_the_region_is_set(mocker):
     """When the region is set in the config the REGION related environment variables should be set"""
     mock_parse_args = mocker.patch('awsprofile.parse_args')
-    mock_parse_args.return_value = ('profile-from-aws-profile-envvar', ['test-command-name'], 'true')
+    mock_parse_args.return_value = ('profile-from-aws-profile-envvar', "test-region", ['test-command-name'], 'true')
     mock_subprocess_call = mocker.patch('awsprofile.subprocess.call')
     mock_subprocess_call.return_value = 0
     mocker.patch.object(awsprofile.botocore.session.Session, 'get_credentials')
@@ -43,8 +44,9 @@ def test_the_region_is_set(mocker):
     mock_put_env = mocker.patch('awsprofile.os.putenv')
     with pytest.raises(SystemExit):
         awsprofile.main()
-    assert mock_put_env.call_count == 5
-    assert mock_put_env.call_args_list == [mocker.call('AWS_DEFAULT_REGION', 'test-region'),
+    assert mock_put_env.call_count == 6
+    assert mock_put_env.call_args_list == [mocker.call('AWS_PROFILE', 'profile-from-aws-profile-envvar'),
+                                           mocker.call('AWS_DEFAULT_REGION', 'test-region'),
                                            mocker.call('AWS_REGION', 'test-region'),
                                            mocker.call('AWS_ACCESS_KEY_ID', 'FAKE_ACCESS'),
                                            mocker.call('AWS_SECRET_ACCESS_KEY', 'FAKE_SECRET'),
@@ -54,7 +56,7 @@ def test_the_region_is_set(mocker):
 def test_cache_called(mocker):
     """"When the AWS_CACHE environment variable is true the credentials should be cached"""
     mock_parse_args = mocker.patch('awsprofile.parse_args')
-    mock_parse_args.return_value = ('profile-from-aws-profile-envvar', ['test-command-name'], 'true')
+    mock_parse_args.return_value = ('profile-from-aws-profile-envvar', "test-region", ['test-command-name'], 'true')
     mock_parse_configure_cache = mocker.patch('awsprofile.configure_cache')
     mock_subprocess_call = mocker.patch('awsprofile.subprocess.call')
     mock_subprocess_call.return_value = 0
@@ -73,7 +75,7 @@ def test_cache_called(mocker):
 def test_cache_not_called(mocker):
     """"When the AWS_CACHE environment variable is false the credentials should be cached"""
     mock_parse_args = mocker.patch('awsprofile.parse_args')
-    mock_parse_args.return_value = ('profile-from-aws-profile-envvar', ['test-command-name'], 'false')
+    mock_parse_args.return_value = ('profile-from-aws-profile-envvar', "test-region", ['test-command-name'], 'false')
     mock_parse_configure_cache = mocker.patch('awsprofile.configure_cache')
     mock_subprocess_call = mocker.patch('awsprofile.subprocess.call')
     mock_subprocess_call.return_value = 0
@@ -94,7 +96,7 @@ def test_token_type_set_correctly(token_type, expected_env_variable, mocker):
     """"The AWS_TOKEN_TYPE environment variable cause the correct environment variable to be set"""
     os.environ['AWS_TOKEN_TYPE'] = token_type
     mock_parse_args = mocker.patch('awsprofile.parse_args')
-    mock_parse_args.return_value = ('profile-from-aws-profile-envvar', ['test-command-name'], 'false')
+    mock_parse_args.return_value = ('profile-from-aws-profile-envvar', "test-region", ['test-command-name'], 'false')
     mocker.patch('awsprofile.configure_cache')
     mock_subprocess_call = mocker.patch('awsprofile.subprocess.call')
     mock_subprocess_call.return_value = 0
@@ -107,8 +109,9 @@ def test_token_type_set_correctly(token_type, expected_env_variable, mocker):
     mock_put_env = mocker.patch('awsprofile.os.putenv')
     with pytest.raises(SystemExit):
         awsprofile.main()
-    assert mock_put_env.call_count == 5
-    assert mock_put_env.call_args_list == [mocker.call('AWS_DEFAULT_REGION', 'test-region'),
+    assert mock_put_env.call_count == 6
+    assert mock_put_env.call_args_list == [mocker.call('AWS_PROFILE', 'profile-from-aws-profile-envvar'),
+                                           mocker.call('AWS_DEFAULT_REGION', 'test-region'),
                                            mocker.call('AWS_REGION', 'test-region'),
                                            mocker.call('AWS_ACCESS_KEY_ID', 'FAKE_ACCESS'),
                                            mocker.call('AWS_SECRET_ACCESS_KEY', 'FAKE_SECRET'),

--- a/tests/test_parse_args.py
+++ b/tests/test_parse_args.py
@@ -24,23 +24,25 @@ def test_empty_command_prints_help(command_line, capsys, mocker):
     assert out.startswith('usage')
 
 
-@pytest.mark.parametrize("command_line,expected_profile,expected_commands",
-                         [("aws-profile command", None, ["command"]),
-                          ("aws-profile command -a argument", None, ["command", "-a", "argument"]),
-                          ("aws-profile -p test-profile-name command", 'test-profile-name', ["command"]),
-                          ("aws-profile -p test-profile-name command -a argument", 'test-profile-name',
+@pytest.mark.parametrize("command_line,expected_profile,expected_region,expected_commands",
+                         [("aws-profile command", None, None, ["command"]),
+                          ("aws-profile command -a argument", None, None, ["command", "-a", "argument"]),
+                          ("aws-profile -p test-profile-name command", 'test-profile-name', None, ["command"]),
+                          ("aws-profile -p test-profile-name command -a argument", 'test-profile-name', None,
                            ["command", "-a", "argument"]),
-                          ("aws-profile --profile long-test-profile-name command", 'long-test-profile-name',
+                          ("aws-profile --profile long-test-profile-name command", 'long-test-profile-name', None,
                            ["command"]),
                           (
                                   "aws-profile --profile long-test-profile-name command -a argument",
-                                  'long-test-profile-name', ["command", "-a", "argument"])]
+                                  'long-test-profile-name', None, ["command", "-a", "argument"]),
+                          ("aws-profile -p test-profile-name -r test-region command", 'test-profile-name', "test-region", ["command"])
+                          ]
                          )
-def test_profile_is_set_as_expected(command_line, expected_profile, expected_commands, mocker):
+def test_profile_is_set_as_expected(command_line, expected_profile, expected_region, expected_commands, mocker):
     """It should return the correct value for the profile, the option from the command line if present or None"""
     mocker.patch('sys.argv', command_line.split(' '))
     result = parse_args()
-    assert (expected_profile, expected_commands, 'true') == result
+    assert (expected_profile, expected_region, expected_commands, 'true') == result
 
 
 @pytest.mark.parametrize("envvar,expected", [
@@ -59,4 +61,4 @@ def test_cache_envar_set_to_anything_other_than_false_or_FALSE(envvar, expected,
     mocker.patch('sys.argv', ['aws-profile', 'test-command-name'])
     os.environ['AWS_CACHE'] = envvar
     result = parse_args()
-    assert (None, ['test-command-name'], expected) == result
+    assert (None, None, ['test-command-name'], expected) == result


### PR DESCRIPTION
```
aws-profile -r us-east-1 aws configure list

# returns
   profile                      dev           manual    --profile
access_key     ****************PMHB              env
secret_key     ****************pK/7              env
    region                us-east-1              env    AWS_DEFAULT_REGION
```